### PR TITLE
Use OSError instead of WindowsError exception. 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,7 @@ def load_init_file():
     initfile = os.path.join(folder, "init")
     try:
         os.makedirs(folder)
-    except WindowsError:
+    except OSError:
         pass
 
     if not os.path.exists(initfile):


### PR DESCRIPTION
WindowsError does not exist on non-windows platforms (is a subclass of OSError) and causes an error on startup when the plugin is loaded.
